### PR TITLE
Add GitHub Action to build using Docker and push to GitHub artifacts

### DIFF
--- a/client/.github/workflows/docker-build.yml
+++ b/client/.github/workflows/docker-build.yml
@@ -1,0 +1,41 @@
+name: Docker Build and Push
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push client Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./client
+          push: true
+          tags: ghcr.io/mcp-agents-ai/mcp-marketplace-client:latest
+
+      - name: Build and push server Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./server
+          push: true
+          tags: ghcr.io/mcp-agents-ai/mcp-marketplace-server:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   server:
-    image: mcp-marketplace-server
+    image: ghcr.io/mcp-agents-ai/mcp-marketplace-server
     build:
       context: ./server
     ports:
@@ -11,7 +11,7 @@ services:
       - PORT=3001
 
   client:
-    image: mcp-marketplace-client
+    image: ghcr.io/mcp-agents-ai/mcp-marketplace-client
     build:
       context: ./client
     ports:


### PR DESCRIPTION
Fixes #6

Add GitHub Action to build Docker images and push to GitHub Container Registry.

* Create `client/.github/workflows/docker-build.yml` to define a GitHub Action workflow for building and pushing Docker images for the client and server.
* Trigger the workflow on push and pull request events to the `main` branch.
* Add steps to check out the repository, set up Docker Buildx, log in to GitHub Container Registry, and build and push Docker images for the client and server.
* Update `docker-compose.yml` to use the new image URLs `ghcr.io/mcp-agents-ai/mcp-marketplace-server` and `ghcr.io/mcp-agents-ai/mcp-marketplace-client`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mcp-agents-ai/mcp-marketplace/pull/7?shareId=e5598884-7c7d-475c-a6af-9decb9bd6b2b).