### PR TITLE
Add GitHub action to build using Docker and push to GitHub Artifacts

### DIFF
--- a/client/.github/workflows/docker-build.yml
+++ b/client/.github/workflows/docker-build.yml
@@ -33,9 +33,21 @@ jobs:
           push: true
           tags: ghcr.io/mcp-agents-ai/mcp-marketplace-client:latest
 
+      - name: Upload client Docker image to GitHub Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: client-docker-image
+          path: ./client
+
       - name: Build and push server Docker image
         uses: docker/build-push-action@v2
         with:
           context: ./server
           push: true
           tags: ghcr.io/mcp-agents-ai/mcp-marketplace-server:latest
+
+      - name: Upload server Docker image to GitHub Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: server-docker-image
+          path: ./server


### PR DESCRIPTION
Related to #6

Add steps to upload Docker images to GitHub Artifacts in GitHub Action workflow.

* Add a step to upload the client Docker image to GitHub Artifacts using `actions/upload-artifact@v2`.
* Add a step to upload the server Docker image to GitHub Artifacts using `actions/upload-artifact@v2`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mcp-agents-ai/mcp-marketplace/pull/8?shareId=06eb0d78-0221-4e0c-9c33-de720ddf9f91).