### PR TITLE
refactor: add TypeScript types to request and response in hub routes

### DIFF
--- a/server/src/routes/hub.ts
+++ b/server/src/routes/hub.ts
@@ -1,10 +1,10 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
 import { refreshCacheIfNeeded } from '../lib/mcpServers.js';
 
 const router = Router();
 
 // GET /servers - returns server data with hubId included
-router.get('/servers', async (_req, res) => {
+router.get('/servers', async (_req: Request, res: Response): Promise<void> => {
   try {
     const mcpServersCache = await refreshCacheIfNeeded();
     
@@ -18,7 +18,7 @@ router.get('/servers', async (_req, res) => {
 });
 
 // GET /servers/:hubId - returns a specific server by hubId
-router.get('/servers/:hubId', async (req, res) => {
+router.get('/servers/:hubId', async (req: Request, res: Response): Promise<void> => {
   try {
     const { hubId } = req.params;
     const mcpServersCache = await refreshCacheIfNeeded();
@@ -27,7 +27,8 @@ router.get('/servers/:hubId', async (req, res) => {
     const server = mcpServersCache.find(server => server.hubId === hubId);
     
     if (!server) {
-      return res.status(404).json({ error: 'Server not found' });
+      res.status(404).json({ error: 'Server not found' });
+      return;
     }
     
     res.json(server);


### PR DESCRIPTION
This pull request includes several changes to the `server/src/routes/hub.ts` file to improve type safety and code clarity. The most important changes are the addition of type annotations for the `Request` and `Response` objects and the modification of the error handling in the `/servers/:hubId` route.

Improvements to type safety:

* Added `Request` and `Response` type annotations to the `router.get('/servers')` route handler.
* Added `Request` and `Response` type annotations to the `router.get('/servers/:hubId')` route handler.

Code clarity improvements:

* Modified the error handling in the `router.get('/servers/:hubId')` route to return immediately after setting the response status and JSON body.