### PR TITLE
add: duplicate hub API proxy configuration in nginx

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -31,4 +31,14 @@ server {
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
     }
+
+    # Proxy hub API requests to the server
+    location /v1/hub {
+        proxy_pass http://server:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
 }


### PR DESCRIPTION
This pull request includes an update to the `client/nginx.conf` file to improve the routing of API requests.

Routing improvements:

* [`client/nginx.conf`](diffhunk://#diff-e8c3280c989f11c77facbf07e4c00bc6b488b220ccd6869bc6cb4d9d218632ddR34-R43): Added a new location block to proxy hub API requests to the server at `http://server:3001`, including necessary headers for handling upgrades and bypassing cache.