### PR TITLE
Add volume mapping for server data and comment out split JSON copy in Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "3001:3001"
     env_file:
       - ../.github-private/env_files/.env
+    volumes:
+      - ./server/src/data/split:/app/dist/data/split/
 
   client:
     image: ghcr.io/mcp-agents-ai/mcp-agents-hub-client:latest

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,7 +16,7 @@ COPY src/data/mcp-servers.json dist/data/mcp-servers.json
 # Create split directory if it doesn't exist
 RUN mkdir -p dist/data/split
 # Copy all files from split directory
-COPY src/data/split/*.json dist/data/split/
+# COPY src/data/split/*.json dist/data/split/
 
 # Build the application
 RUN npm run build


### PR DESCRIPTION
#32 

This pull request includes changes to the `docker-compose.yml` and `server/Dockerfile` files to update the handling of the `split` directory. The most important changes include adding a volume mapping for the `split` directory in the `docker-compose.yml` file and commenting out the line that copies JSON files from the `split` directory in the `server/Dockerfile`.

Changes to `docker-compose.yml`:

* Added a volume mapping for the `split` directory to the `server` service.

Changes to `server/Dockerfile`:

* Commented out the line that copies JSON files from the `split` directory to the `dist` directory.