### PR TITLE
enhance GitHub URL conversion to support subfolder paths and improve …

### DIFF
--- a/server/tests/mock/github-url-conversion.test.ts
+++ b/server/tests/mock/github-url-conversion.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { convertToRawReadmeUrl } from '../../src/lib/githubEnrichment';
+
+describe('GitHub URL conversion', () => {
+  it('should convert repository root URLs to raw README URLs', () => {
+    const input = 'https://github.com/modelcontextprotocol/servers';
+    const expected = 'https://raw.githubusercontent.com/modelcontextprotocol/servers/refs/heads/main/README.md';
+    expect(convertToRawReadmeUrl(input)).toBe(expected);
+  });
+
+  it('should handle repository root URLs with trailing slash', () => {
+    const input = 'https://github.com/modelcontextprotocol/servers/';
+    const expected = 'https://raw.githubusercontent.com/modelcontextprotocol/servers/refs/heads/main/README.md';
+    expect(convertToRawReadmeUrl(input)).toBe(expected);
+  });
+
+  it('should convert subfolder URLs to raw README URLs in that subfolder', () => {
+    const input = 'https://github.com/modelcontextprotocol/servers/tree/main/src/aws-kb-retrieval-server';
+    const expected = 'https://raw.githubusercontent.com/modelcontextprotocol/servers/refs/heads/main/src/aws-kb-retrieval-server/README.md';
+    expect(convertToRawReadmeUrl(input)).toBe(expected);
+  });
+
+  it('should handle different subfolder paths', () => {
+    const input = 'https://github.com/modelcontextprotocol/servers/tree/main/src/memory';
+    const expected = 'https://raw.githubusercontent.com/modelcontextprotocol/servers/refs/heads/main/src/memory/README.md';
+    expect(convertToRawReadmeUrl(input)).toBe(expected);
+  });
+
+  it('should handle deep nesting and different branches', () => {
+    const input = 'https://github.com/modelcontextprotocol/servers/tree/development/src/deep/nested/folder';
+    const expected = 'https://raw.githubusercontent.com/modelcontextprotocol/servers/refs/heads/development/src/deep/nested/folder/README.md';
+    expect(convertToRawReadmeUrl(input)).toBe(expected);
+  });
+
+  it('should throw an error for invalid GitHub URLs', () => {
+    const input = 'https://github.com/user';
+    expect(() => convertToRawReadmeUrl(input)).toThrow('Invalid GitHub URL format');
+  });
+});


### PR DESCRIPTION
This pull request includes changes to enhance the GitHub URL conversion function and adds tests to ensure its correctness. The main changes include improving the `convertToRawReadmeUrl` function to handle subfolder URLs and adding comprehensive test cases.

Enhancements to GitHub URL conversion:

* [`server/src/lib/githubEnrichment.ts`](diffhunk://#diff-b0999be889c1c5de44a79bc11f15ced51499533e497341cc27f493a70c8c428dR39-R69): Updated the `convertToRawReadmeUrl` function to handle both repository root URLs and subfolder URLs, and to throw an error for invalid GitHub URLs.

Addition of test cases:

* [`server/tests/mock/github-url-conversion.test.ts`](diffhunk://#diff-c16ae695251353454c69264b1a690ec189434cb01f7895bbbffbdfc08e81155bR1-R39): Added test cases to validate the `convertToRawReadmeUrl` function, including tests for repository root URLs, URLs with trailing slashes, subfolder URLs, deep nesting, different branches, and invalid URLs.…error handling