### PR TITLE
implement download endpoint to retrieve server data with README content and add integration tests

### DIFF
--- a/server/src/routes/mcp.ts
+++ b/server/src/routes/mcp.ts
@@ -1,5 +1,6 @@
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
 import { McpServer, refreshCacheIfNeeded, getCleanedServersData } from '../lib/mcpServers.js';
+import { fetchReadmeContent } from '../lib/githubEnrichment.js';
 
 const router = Router();
 
@@ -14,6 +15,50 @@ router.get('/servers', async (_req, res) => {
     console.log(`v1/mcp/servers Served cached MCP servers data at ${new Date().toISOString()}`);
   } catch (error) {
     console.error('Error serving MCP servers:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// POST /download - Get server data with README content
+router.post('/download', async (req: Request, res: Response) => {
+  try {
+    // Validate request body
+    const { mcpId } = req.body;
+    if (!mcpId) {
+      return res.status(400).json({ error: 'mcpId is required' });
+    }
+
+    // Get the latest servers data
+    const mcpServersCache = await refreshCacheIfNeeded();
+    
+    // Find the requested server by mcpId
+    const server = mcpServersCache.find(server => server.mcpId === mcpId);
+    if (!server) {
+      return res.status(404).json({ error: 'Server not found' });
+    }
+
+    // Get README content if GitHub URL is available
+    let readmeContent = '';
+    if (server.githubUrl) {
+      try {
+        readmeContent = await fetchReadmeContent(server.githubUrl);
+      } catch (readmeError) {
+        console.error(`Error fetching README for ${server.mcpId}:`, readmeError);
+        // Continue even if README fetch fails
+      }
+    }
+
+    // Prepare the response data
+    const responseData = {
+      ...server,
+      readmeContent
+    };
+
+    // Return the enriched server data
+    res.json(responseData);
+    console.log(`v1/mcp/download Served data for ${server.mcpId} at ${new Date().toISOString()}`);
+  } catch (error) {
+    console.error('Error serving server download data:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/server/tests/integration/mcp-download.test.ts
+++ b/server/tests/integration/mcp-download.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import axios from 'axios';
+import express from 'express';
+import cors from 'cors';
+import { Server } from 'http';
+import mcpRouter from '../../src/routes/mcp.js';
+
+// Mock the mcpServers and githubEnrichment modules
+vi.mock('../../src/lib/mcpServers.js', () => {
+  const mockServer = {
+    mcpId: 'github.com/modelcontextprotocol/servers/tree/main/src/slack',
+    githubUrl: 'https://github.com/modelcontextprotocol/servers/tree/main/src/slack',
+    name: 'Slack',
+    author: 'modelcontextprotocol',
+    description: 'Enables AI assistants to interact with Slack workspaces',
+    codiconIcon: 'comment-discussion',
+    logoUrl: 'https://storage.googleapis.com/cline_public_images/slack.png',
+    category: 'communication',
+    tags: ['slack', 'messaging'],
+    requiresApiKey: false,
+    isRecommended: true,
+    githubStars: 28615,
+    createdAt: '2025-02-17T22:23:00.036614Z',
+    updatedAt: '2025-02-17T22:23:00.036614Z',
+    lastGithubSync: '2025-04-01T03:57:50.288993Z'
+  };
+
+  return {
+    refreshCacheIfNeeded: vi.fn().mockResolvedValue([mockServer]),
+    getCleanedServersData: vi.fn().mockReturnValue([mockServer])
+  };
+});
+
+vi.mock('../../src/lib/githubEnrichment.js', () => {
+  return {
+    fetchReadmeContent: vi.fn().mockResolvedValue(
+      '# Slack MCP Server\n\nMCP Server for the Slack API, enabling Claude to interact with Slack workspaces.\n\n## Tools\n\n1. slack_list_channels\n   - List public channels in the workspace'
+    )
+  };
+});
+
+describe('MCP API Download Endpoint', () => {
+  let server: Server;
+  let app: express.Express;
+  const PORT = 4000;
+  const BASE_URL = `http://localhost:${PORT}/v1/mcp`;
+
+  beforeAll(async () => {
+    // Create a test server
+    app = express();
+    app.use(express.json());
+    app.use(cors());
+    app.use('/v1/mcp', mcpRouter);
+
+    // Start the server
+    return new Promise<void>((resolve) => {
+      server = app.listen(PORT, () => {
+        console.log(`Test server running on port ${PORT}`);
+        resolve();
+      });
+    });
+  });
+
+  afterAll(() => {
+    // Close the server after tests
+    return new Promise<void>((resolve) => {
+      server.close(() => {
+        console.log('Test server closed');
+        resolve();
+      });
+    });
+  });
+
+  it('should return server data with README content when given a valid mcpId', async () => {
+    const response = await axios.post(`${BASE_URL}/download`, {
+      mcpId: 'github.com/modelcontextprotocol/servers/tree/main/src/slack'
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data).toHaveProperty('mcpId');
+    expect(response.data).toHaveProperty('name', 'Slack');
+    expect(response.data).toHaveProperty('readmeContent');
+    expect(response.data.readmeContent).toContain('Slack MCP Server');
+  });
+
+  it('should return 400 when mcpId is not provided', async () => {
+    try {
+      await axios.post(`${BASE_URL}/download`, {});
+      // If the request succeeds, fail the test
+      expect(true).toBe(false); // This should not be reached
+    } catch (error: any) {
+      expect(error.response.status).toBe(400);
+      expect(error.response.data).toHaveProperty('error', 'mcpId is required');
+    }
+  });
+
+  it('should return 404 when server with provided mcpId is not found', async () => {
+    try {
+      await axios.post(`${BASE_URL}/download`, {
+        mcpId: 'invalid-mcp-id'
+      });
+      // If the request succeeds, fail the test
+      expect(true).toBe(false); // This should not be reached
+    } catch (error: any) {
+      expect(error.response.status).toBe(404);
+      expect(error.response.data).toHaveProperty('error', 'Server not found');
+    }
+  });
+});

--- a/server/tests/results/0a0cff94-1f03-4d1f-b5cc-a41d464f575e_test_results.json
+++ b/server/tests/results/0a0cff94-1f03-4d1f-b5cc-a41d464f575e_test_results.json
@@ -8,16 +8,17 @@
   "extractedInfo": {
     "name": "AWS Knowledge Base Retrieval MCP Server",
     "description": "An MCP server implementation for retrieving information from the AWS Knowledge Base using the Bedrock Agent Runtime.",
-    "Installation_instructions": "Docker: `docker build -t mcp/aws-kb-retrieval -f src/aws-kb-retrieval-server/Dockerfile .`",
-    "Usage_instructions": "Add the server configuration to your `claude_desktop_config.json` file with appropriate AWS credentials and region settings. Use the `retrieve_from_aws_kb` tool to perform retrieval operations by providing a query and Knowledge Base ID.",
+    "Installation_instructions": "You can install the server using Docker or NPX. For Docker, build the image using the provided Dockerfile. For NPX, use the command 'npx -y @modelcontextprotocol/server-aws-kb-retrieval'. Ensure AWS credentials are configured either via IAM Access Keys or AWS SSO.",
+    "Usage_instructions": "Use the 'retrieve_from_aws_kb' tool to perform retrieval operations. Inputs include 'query', 'knowledgeBaseId', and optionally 'n' for the number of results. The response includes raw context and structured RAG sources with metadata.",
     "features": [
       "RAG (Retrieval-Augmented Generation): Retrieve context from the AWS Knowledge Base based on a query and a Knowledge Base ID.",
       "Supports multiple results retrieval: Option to retrieve a customizable number of results."
     ],
     "prerequisites": [
-      "AWS access key ID, secret access key, and region for IAM Access Keys or AWS SSO configuration.",
-      "Appropriate permissions for Bedrock Agent Runtime operations.",
-      "Docker or Node.js installed for running the server."
+      "AWS access key ID, secret access key, and region from the AWS Management Console.",
+      "AWS CLI configured with SSO profile if using AWS SSO.",
+      "Docker installed if using Docker for installation.",
+      "Node.js installed if using NPX or running from a local repository."
     ]
   }
 }


### PR DESCRIPTION
This pull request introduces a new endpoint to the MCP server and includes corresponding tests and documentation updates. The most important changes are the addition of the `/download` endpoint, the integration of README content fetching, and the creation of integration tests for the new endpoint.

### New Endpoint and Features:

* [`server/src/routes/mcp.ts`](diffhunk://#diff-ebd047e9bfbe7f8c7e208d2979e3039bb64aa3d3de21508b22a78c6a8b1b6a91R22-R65): Added a new POST `/download` endpoint that retrieves server data along with README content from GitHub if available.

### Testing:

* [`server/tests/integration/mcp-download.test.ts`](diffhunk://#diff-74d87523121b696ff424ccf8b1d03464fdbfce44c00bbb48a1403a93a9c801d8R1-R109): Added integration tests for the new `/download` endpoint, including tests for valid requests, missing `mcpId`, and non-existent servers.

### Mocking and Setup:

* [`server/tests/integration/mcp-download.test.ts`](diffhunk://#diff-74d87523121b696ff424ccf8b1d03464fdbfce44c00bbb48a1403a93a9c801d8R1-R109): Mocked the `mcpServers` and `githubEnrichment` modules to simulate server data and README content fetching for testing purposes.

### Documentation Updates:

* [`server/tests/results/0a0cff94-1f03-4d1f-b5cc-a41d464f575e_test_results.json`](diffhunk://#diff-6a5aea9ed4e10b35e847d418e0163546e82584e4badea91446cc7027fc110bd9L11-R21): Updated installation and usage instructions for the AWS Knowledge Base Retrieval MCP Server, providing more detailed steps for Docker and NPX installations.

### Import Adjustments:

* [`server/src/routes/mcp.ts`](diffhunk://#diff-ebd047e9bfbe7f8c7e208d2979e3039bb64aa3d3de21508b22a78c6a8b1b6a91L1-R3): Updated imports to include `Request` and `Response` from `express` and added import for `fetchReadmeContent`.